### PR TITLE
feat: export runtime types as much as possible

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -40,17 +40,14 @@
     "rules": {
       "correctness": {
         "useExhaustiveDependencies": "off",
-        "noEmptyPattern": "off",
-        "noUnusedImports": {}
+        "noEmptyPattern": "off"
       },
       "a11y": {
         "useKeyWithClickEvents": "off",
         "useSemanticElements": "off"
       },
       "style": {
-        "recommended": false,
-        "useImportType": {},
-        "useExportType": {}
+        "recommended": false
       },
       "complexity": {
         "noForEach": "warn",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "vitest-types": "file:.."
+  }
+}

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      vitest-types:
+        specifier: file:..
+        version: file:..
+
+packages:
+
+  vitest-types@file:..:
+    resolution: {directory: .., type: directory}
+
+snapshots:
+
+  vitest-types@file:..: {}

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -1,5 +1,7 @@
-import { expect, test } from "vitest-demo";
+import { expect, test } from "vitest";
 
 test("test", () => {
   expect("a").toMatchSnapshot();
 });
+
+it("a", () => {});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "resolveJsonModule": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "target": "ES2022",
+    "types": ["vitest-types/globals", "vitest-types"]
+  },
+  "include": [
+    "test.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,17 +1,22 @@
 {
   "name": "vitest-types",
   "version": "0.0.0-PLACEHOLDER",
-  "type": "module",
+  "types": "./dist/2.d.ts",
   "exports": {
-    "./vitest-218": {
-      "types": "./dist/vitest-218/index.d.ts"
+    ".": {
+      "types": "./dist/2.d.ts"
+    },
+    "./globals": {
+      "types": "./dist/2/globals.d.ts"
     },
     "./*": {
       "types": "./dist/*.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "files": ["dist"],
   "scripts": {
-    "build": "bun build.ts",
+    "build": "pnpm --package tsx@4.19.2 dlx tsx build.ts",
     "prepare": "pnpm --package husky@9.1.1 dlx husky",
     "prepack": "pnpm build",
     "deploy": "npm pack"
@@ -22,7 +27,7 @@
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.10.2",
     "lodash-es": "^4.17.21",
-    "vitest218": "npm:vitest@2.1.8"
+    "vitest2": "npm:vitest@2.1.8"
   },
   "nano-staged": {
     "*.{js,ts,cts,mts}": "biome check --write --diagnostic-level=error --no-errors-on-unmatched"
@@ -30,7 +35,7 @@
   "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee",
   "pnpm": {
     "patchedDependencies": {
-      "@microsoft/api-extractor": "patches/@microsoft__api-extractor.patch"
+      "vitest@2.1.8": "patches/vitest@2.1.8.patch"
     }
   }
 }

--- a/patches/@microsoft__api-extractor.patch
+++ b/patches/@microsoft__api-extractor.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/analyzer/AstSymbolTable.js b/lib/analyzer/AstSymbolTable.js
-index 937231313ecad748e4e2019a8e266c30d9d7beb5..410af782164b0bc1f40a89d6cd0595b1a40f654f 100644
+index 937231313ecad748e4e2019a8e266c30d9d7beb5..d9dfb163839b6b50e81150f5ae09b11f6c36e124 100644
 --- a/lib/analyzer/AstSymbolTable.js
 +++ b/lib/analyzer/AstSymbolTable.js
 @@ -123,13 +123,16 @@ class AstSymbolTable {
@@ -27,10 +27,11 @@ index 937231313ecad748e4e2019a8e266c30d9d7beb5..410af782164b0bc1f40a89d6cd0595b1
          }
          // Is this node declaring a new AstSymbol?
 -        const newGoverningAstDeclaration = this._fetchAstDeclaration(node, governingAstDeclaration.astSymbol.isExternal);
-+        const newGoverningAstDeclaration = this._fetchAstDeclaration(node, governingAstDeclaration.astSymbol.isExternal) ?? [governingAstDeclaration];
-         for (const childNode of node.getChildren()) {
+-        for (const childNode of node.getChildren()) {
 -            this._analyzeChildTree(childNode, newGoverningAstDeclaration || governingAstDeclaration);
-+            for (const d of newGoverningAstDeclaration) {
++        const newGoverningAstDeclaration = this._fetchAstDeclaration(node, governingAstDeclaration.astSymbol.isExternal) ?? [governingAstDeclaration];
++        for (const d of newGoverningAstDeclaration) {
++            for (const childNode of node.getChildren()) {
 +                this._analyzeChildTree(childNode, d);
 +            }
          }

--- a/patches/vitest@2.1.8.patch
+++ b/patches/vitest@2.1.8.patch
@@ -1,0 +1,72 @@
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 2bbe68cce613978444bd87c45ccaddd50031e06b..39554be16fef132817d567646769c8c43bd3fe78 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -7,8 +7,9 @@ export { A as AfterSuiteRunMeta, g as ModuleCache } from './chunks/environment.L
+ import { a as BirpcReturn, b as WorkerRPC$1 } from './chunks/worker.tN5KGIih.js';
+ export { C as ContextRPC, d as ContextTestEnvironment, e as ResolveIdFunction, c as RunnerRPC, R as RuntimeRPC, W as WorkerGlobalState } from './chunks/worker.tN5KGIih.js';
+ import './chunks/vite.C-N5BBZe.js';
+-import { PromisifyAssertion, Tester, ExpectStatic } from '@vitest/expect';
+-export { Assertion, AsymmetricMatchersContaining, ExpectPollOptions, ExpectStatic, JestAssertion } from '@vitest/expect';
++import { PromisifyAssertion, Tester } from '@vitest/expect';
++export { AsymmetricMatchersContaining, JestAssertion } from '@vitest/expect';
++import { Assertion as Assertion$1, MatcherState as MatcherState$1, ExpectStatic as ExpectStatic$1 } from '@vitest/expect'
+ import { Plugin } from '@vitest/pretty-format';
+ import { SnapshotState } from '@vitest/snapshot';
+ export { SnapshotData, SnapshotMatchOptions, SnapshotResult, SnapshotSerializer, SnapshotStateOptions, SnapshotSummary, SnapshotUpdateState, UncheckedSnapshot } from '@vitest/snapshot';
+@@ -62,8 +63,9 @@ interface InlineSnapshotMatcher<T> {
+     }>(properties: Partial<U>, snapshot?: string, message?: string): void;
+     (message?: string): void;
+ }
+-declare module '@vitest/expect' {
+-    interface MatcherState {
++
++// declare module '@vitest/expect' {
++    interface MatcherState extends MatcherState$1 {
+         environment: VitestEnvironment$1;
+         snapshotState: SnapshotState;
+     }
+@@ -72,7 +74,8 @@ declare module '@vitest/expect' {
+         timeout?: number;
+         message?: string;
+     }
+-    interface ExpectStatic {
++    interface ExpectStatic extends ExpectStatic$1 {
++        <T>(actual: T, message?: string): Assertion<T>;
+         unreachable: (message?: string) => never;
+         soft: <T>(actual: T, message?: string) => Assertion<T>;
+         poll: <T>(actual: () => T, options?: ExpectPollOptions) => PromisifyAssertion<Awaited<T>>;
+@@ -81,7 +84,7 @@ declare module '@vitest/expect' {
+         hasAssertions: () => void;
+         addSnapshotSerializer: (plugin: Plugin) => void;
+     }
+-    interface Assertion<T> {
++    interface Assertion<T> extends Assertion$1<T> {
+         matchSnapshot: SnapshotMatcher<T>;
+         toMatchSnapshot: SnapshotMatcher<T>;
+         toMatchInlineSnapshot: InlineSnapshotMatcher<T>;
+@@ -118,8 +121,8 @@ declare module '@vitest/expect' {
+          */
+         toMatchFileSnapshot: (filepath: string, message?: string) => Promise<void>;
+     }
+-}
+-declare module '@vitest/runner' {
++// }
++// declare module '@vitest/runner' {
+     interface TestContext {
+         expect: ExpectStatic;
+     }
+@@ -138,7 +141,7 @@ declare module '@vitest/runner' {
+     interface TaskResult {
+         benchmark?: BenchmarkResult;
+     }
+-}
++// }
+ 
+ interface SourceMap {
+     file: string;
+@@ -713,3 +716,4 @@ type SerializableSpec = SerializedTestSpecification;
+ type BenchmarkUserOptions = BenchmarkUserOptions$1;
+ 
+ export { type ApiConfig, type ArgumentsType, type Arrayable, type AssertType, type Awaitable, type BaseCoverageOptions, BenchmarkResult, type BenchmarkUserOptions, type BrowserConfigOptions, type BrowserScript, type BrowserUI, type BuiltinEnvironment, type CSSModuleScopeStrategy, type CollectLineNumbers, type CollectLines, type Constructable, type Context, type CoverageIstanbulOptions, type CoverageOptions, type CoverageProvider, type CoverageProviderModule, type CoverageReporter, type CoverageV8Options, type Custom, type CustomProviderOptions, type DepsOptimizationOptions, type DoneCallback, type Environment, type EnvironmentOptions, type EnvironmentReturn, type File, type HappyDOMOptions, type InlineConfig, type JSDOMOptions, ModuleGraphData, type MutableArray, type Nullable, type OnServerRestartHandler, type Pool, type PoolOptions, type ProjectConfig, ProvidedContext, type RawErrsMap, type ReportContext, type Reporter, type ResolvedConfig, type ResolvedCoverageOptions, type ResolvedTestEnvironment, type RootAndTarget, type RuntimeContext, type SequenceHooks, type SequenceSetupFiles, type SerializableSpec, SerializedConfig, SerializedTestSpecification, type Suite, type SuiteHooks, type Task, type TaskBase, type TaskResult, type TaskResultPack, type Test, type TransformModePatterns, type TransformResultWithSource, type TscErrorInfo, type TypecheckConfig, type UserConfig, UserConsoleLog, type UserWorkspaceConfig, type Vitest, type VitestEnvironment, type VitestRunMode, type VitestUtils, type VmEnvironmentReturn, type WebSocketEvents, type WebSocketHandlers, type WebSocketRPC, type WorkerContext, type WorkerRPC, assertType, createExpect, globalExpect as expect, getRunningMode, inject, isFirstRun, isWatchMode, runOnce, vi, vitest };
++export { Assertion, ExpectStatic, MatcherState }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@microsoft/api-extractor':
-    hash: 7bmubortkn52at2forlfzr6kpq
-    path: patches/@microsoft__api-extractor.patch
+  vitest@2.1.8:
+    hash: 67d4jzrslhi5mqwjnzbuj4bm5q
+    path: patches/vitest@2.1.8.patch
 
 importers:
 
@@ -18,7 +18,7 @@ importers:
         version: 1.9.4
       '@microsoft/api-extractor':
         specifier: ^7.48.1
-        version: 7.48.1(patch_hash=7bmubortkn52at2forlfzr6kpq)(@types/node@22.10.2)
+        version: 7.48.1(@types/node@22.10.2)
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -28,9 +28,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
-      vitest218:
+      vitest2:
         specifier: npm:vitest@2.1.8
-        version: vitest@2.1.8(@types/node@22.10.2)
+        version: vitest@2.1.8(patch_hash=67d4jzrslhi5mqwjnzbuj4bm5q)(@types/node@22.10.2)
 
 packages:
 
@@ -843,7 +843,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.48.1(patch_hash=7bmubortkn52at2forlfzr6kpq)(@types/node@22.10.2)':
+  '@microsoft/api-extractor@7.48.1(@types/node@22.10.2)':
     dependencies:
       '@microsoft/api-extractor-model': 7.30.1(@types/node@22.10.2)
       '@microsoft/tsdoc': 0.15.1
@@ -1283,7 +1283,7 @@ snapshots:
       '@types/node': 22.10.2
       fsevents: 2.3.3
 
-  vitest@2.1.8(@types/node@22.10.2):
+  vitest@2.1.8(patch_hash=67d4jzrslhi5mqwjnzbuj4bm5q)(@types/node@22.10.2):
     dependencies:
       '@vitest/expect': 2.1.8
       '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.2))

--- a/src/2/vitest.d.ts
+++ b/src/2/vitest.d.ts
@@ -1,44 +1,68 @@
-export type {
+export {
+  CancelReason,
+  ExtendedContext,
+  OnTestFailedHandler,
+  OnTestFinishedHandler,
+  RunMode,
+  RunnerCustomCase,
+  RunnerTask,
+  RunnerTaskBase,
+  RunnerTaskResult,
+  RunnerTaskResultPack,
+  RunnerTestCase,
+  RunnerTestFile,
+  RunnerTestSuite,
+  SuiteAPI,
+  SuiteCollector,
+  SuiteFactory,
+  TaskContext,
+  TaskCustomOptions,
+  TaskMeta,
+  TaskState,
+  TestAPI,
+  TestContext,
+  TestFunction,
+  TestOptions,
   afterAll,
   afterEach,
   beforeAll,
+  beforeEach,
   describe,
-  expect,
   it,
   onTestFailed,
   onTestFinished,
   suite,
   test,
-} from "vitest218";
-export { TestContext, TaskMeta, File, TaskBase, TaskResult } from "@vitest/runner";
-export { MatcherState, ExpectStatic, Assertion } from "@vitest/expect";
-export { stringify } from "@vitest/utils";
-
-export interface ExpectPollOptions {
-  interval?: number;
-  timeout?: number;
-  message?: string;
-}
-export interface SnapshotMatcher<T> {
-  <
-    U extends {
-      [P in keyof T]: any;
-    },
-  >(
-    snapshot: Partial<U>,
-    message?: string
-  ): void;
-  (message?: string): void;
-}
-export interface InlineSnapshotMatcher<T> {
-  <
-    U extends {
-      [P in keyof T]: any;
-    },
-  >(
-    properties: Partial<U>,
-    snapshot?: string,
-    message?: string
-  ): void;
-  (message?: string): void;
-}
+} from "vitest2";
+export { AfterSuiteRunMeta } from "vitest2";
+export { AsymmetricMatchersContaining, JestAssertion } from "vitest2";
+export {
+  SnapshotData,
+  SnapshotMatchOptions,
+  SnapshotResult,
+  SnapshotSerializer,
+  SnapshotStateOptions,
+  SnapshotSummary,
+  SnapshotUpdateState,
+  UncheckedSnapshot,
+} from "vitest2";
+export { BenchFunction, Benchmark, BenchmarkAPI } from "vitest2";
+export { RuntimeConfig, SerializedCoverageConfig } from "vitest2";
+export {
+  Mock,
+  MockContext,
+  MockInstance,
+  Mocked,
+  MockedClass,
+  MockedFunction,
+  MockedObject,
+} from "vitest2";
+export { bench } from "vitest2";
+export { ExpectTypeOf, expectTypeOf } from "vitest2";
+export { ParsedStack, SerializedError, TestError } from "vitest2";
+export { DiffOptions } from "vitest2";
+export { chai } from "vitest2";
+export { assert, should } from "vitest2";
+export { BenchFactory, BenchOptions, BenchTask, BenchTaskResult } from "vitest2";
+export { expect, Assertion, ExpectStatic, MatcherState } from "vitest2";
+export { assertType } from "vitest2";


### PR DESCRIPTION
1. export runtime types as much as possible
2. add globals.d.ts
3. avoid dts bundle issue caused by `declare module "xxx"`